### PR TITLE
Clean up redefinition of mouse events

### DIFF
--- a/Ember/src/Ember/Events/Event.h
+++ b/Ember/src/Ember/Events/Event.h
@@ -18,7 +18,6 @@ namespace Ember {
 		WindowClose, WindowResize, WindowFocus, WindowLostFocus, WindowMoved,
 		AppTick, AppUpdate, AppRender,
 		KeyPressed, KeyReleased,
-		MouseButtonPressed, MouseButtonReleased, 
 		MouseButtonPressed, MouseButtonReleased, MouseMoved, MouseScrolled
 	};
 


### PR DESCRIPTION
Mentioned issue: #18 

## Changes
- removed redefinitons of `MouseButtonPressed`, `MouseButtonReleased` events 